### PR TITLE
Add support for active detection on full links

### DIFF
--- a/menu.php
+++ b/menu.php
@@ -696,7 +696,9 @@ class Item {
 	 */
 	public function is_active()
 	{
-		return $this->get_url() == URI::current();
+		return
+			$this->get_url() == URI::current() or
+			$this->get_url() == URI::full();
 	}
 
 	/**


### PR DESCRIPTION
Currently the automatically added "active" state only works if the links in the menu don't include the URL base. Which means an item which a link such as `http://mysite.com/category/something` won't be recognized as active since the function computing active state uses `URL::base()` which strips out `http://mysite.com/`.
This pull request fixes that.
