### PR TITLE
Fixed bug in method has_active_child() of class Item

### DIFF
--- a/menu.php
+++ b/menu.php
@@ -749,6 +749,8 @@ class Item {
 					return true;
 			}
 		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Fixed bug in has_active_child() which leads to a return value of false even if there is an active child.
