### PR TITLE
Active subitems

### DIFF
--- a/src/Menu/Items/Item.php
+++ b/src/Menu/Items/Item.php
@@ -90,7 +90,7 @@ class Item extends MenuObject
   public function isActive()
   {
     return
-      $this->getUrl() == trim($this->getRequest()->getPathInfo(), '/') or
+      trim($this->getUrl(), '/') == trim($this->getRequest()->getPathInfo(), '/') or
       $this->getUrl() == $this->getRequest()->fullUrl() or
       $this->getUrl() == $this->getRequest()->url();
   }


### PR DESCRIPTION
The `isActive()`method on line 90 in `Item.php` should have the `trim()` function on both sides else it compares something with a slash against someting without a slash. e.g.

`/admin/user/2/edit == admin/user/2/edit` returns `false`
