### PR TITLE
Fix for raw items returning active for root URL #40

### DIFF
--- a/src/Menu/Items/Item.php
+++ b/src/Menu/Items/Item.php
@@ -109,7 +109,7 @@ class Item extends MenuObject
   public function isActive()
   {
     return
-      trim($this->getUrl(), '/') == trim($this->getRequest()->getPathInfo(), '/') or
+      (!is_null($this->getUrl()) and trim($this->getUrl(), '/') == trim($this->getRequest()->getPathInfo(), '/')) or
       $this->getUrl() == $this->getRequest()->fullUrl() or
       $this->getUrl() == $this->getRequest()->url() or
       $this->hasActivePatterns();

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -25,6 +25,13 @@ class ItemTest extends MenuTests
     $this->assertHTML($matcher, $item->render());
   }
 
+  public function testRawItemNotActive()
+  {
+    $item = new Item(static::$itemList, static::$raw);
+
+    $this->assertFalse($item->isActive());
+  }
+
   public function testCanCreateItemWithSublist()
   {
     $sublist = static::$itemList;


### PR DESCRIPTION
Not sure how you want to fix this, but this is one option. This solves a problem I encountered when a raw item would be "active" when on the homepage `/`.
