### PR TITLE
Added PR#41 and fixed root url item active check (for subdirectories).

### DIFF
--- a/src/Menu/Items/Item.php
+++ b/src/Menu/Items/Item.php
@@ -108,10 +108,13 @@ class Item extends MenuObject
    */
   public function isActive()
   {
+    $url     = rtrim($this->getUrl(), '/');
+    $request = $this->getRequest();
+    
     return
-      trim($this->getUrl(), '/') == trim($this->getRequest()->getPathInfo(), '/') or
-      $this->getUrl() == $this->getRequest()->fullUrl() or
-      $this->getUrl() == $this->getRequest()->url() or
+      (!is_null($this->getUrl()) and $url === rtrim($request->getPathInfo(), '/')) or
+      $url === rtrim($request->fullUrl(), '/') or
+      $url === rtrim($request->url(), '/') or
       $this->hasActivePatterns();
   }
 

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -25,6 +25,13 @@ class ItemTest extends MenuTests
     $this->assertHTML($matcher, $item->render());
   }
 
+  public function testRawItemNotActive()
+  {
+    $item = new Item(static::$itemList, static::$raw);
+
+    $this->assertFalse($item->isActive());
+  }
+
   public function testCanCreateItemWithSublist()
   {
     $sublist = static::$itemList;


### PR DESCRIPTION
Added pull request as suggested by @dustingraham (to prevent conflict) and fixed active check for the root item.

When using Laravel in a subdirectory (http://example.com/sub/ for example) the item for the route `/` wouldn't be activated. The `$request->fullUrl()` call returned the url **with** a trailing slash - while `$this->getUrl()` returned the url **without** the trailing slash.

Also cached the `$url` and `$request` variables and added identical comparison operators (`===`) to speed things up a little.
