### PR TITLE
This commit resolves #67

### DIFF
--- a/src/Menu/Items/ItemList.php
+++ b/src/Menu/Items/ItemList.php
@@ -557,6 +557,8 @@ class ItemList extends MenuObject
     // Collect all items
     $activeItem = $this->findActiveItem();
 
+    $separator  = $this->getOption('item_list.breadcrumb_separator');
+
     // Make the breadcrumbs
     $itemList = new ItemList(array(), 'breadcrumbs');
 
@@ -568,8 +570,12 @@ class ItemList extends MenuObject
       while($nextItem = $activeItem->getParent()) {
         if(is_null($nextItem->getParent())) break;
 
-        // Add a seperator and the link
-        $itemList->raw('/');
+        // Add a separator and the link
+        if ( ! empty($separator)
+        {
+          $itemList->raw($separator);
+        }
+
         $itemList->addContent($nextItem->getParent()->getContent());
 
         // Set the activeItem for the next iteration

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -26,6 +26,10 @@
     // The default ItemList element
     'element' => 'ul',
 
+    // The default breadcrumb separator, set to '' to not output any separators for
+    // use with bootstrap.
+    'breadcrumb_separator' => '/',
+
     // A prefix to prepend the links URLs with
     'prefix'         => null,
 


### PR DESCRIPTION
Added configuration for choosing a breadcrumb separator, this helps when you are using something like twitter bootstrap which adds / via CSS.

I have found this menu package very useful, however not having configurable breadcrumb separators caused a few issues on my latest project. I found this functionality useful and so have issued a pull request so others may benefit :)
