### PR TITLE
The element of an ItemList is now retrieved correctly

### DIFF
--- a/src/Menu/Items/ItemList.php
+++ b/src/Menu/Items/ItemList.php
@@ -293,7 +293,7 @@ class ItemList extends MenuObject
   public function getElement()
   {
     $element = $this->getOption('item_list.element');
-    if( ! is_null($this->element))
+    if(is_null($this->element))
     {
       $element = $this->element;
     }


### PR DESCRIPTION
The element of an ItemList is now retrieved correctly when it has been set by the user.
