### PR TITLE
Correction to issue #75

### DIFF
--- a/src/Menu/Items/ItemList.php
+++ b/src/Menu/Items/ItemList.php
@@ -293,7 +293,7 @@ class ItemList extends MenuObject
   public function getElement()
   {
     $element = $this->getOption('item_list.element');
-    if(is_null($this->element))
+    if(is_null($element))
     {
       $element = $this->element;
     }

--- a/src/Menu/Items/ItemList.php
+++ b/src/Menu/Items/ItemList.php
@@ -293,7 +293,7 @@ class ItemList extends MenuObject
   public function getElement()
   {
     $element = $this->getOption('item_list.element');
-    if( ! is_null($this->element))
+    if(is_null($this->element))
     {
       $element = $this->element;
     }


### PR DESCRIPTION
This should be the correct fix as it should check for null on the local $element instead of the object's global $element.